### PR TITLE
Remove peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
     "url": "http://github.com/christophercliff/watch-ignore-webpack-plugin"
   },
   "license": "MIT",
-  "peerDependencies": {
-    "webpack": "1.5.x"
-  },
   "devDependencies": {
     "assert-dir-equal": "^1.0.1",
     "bluebird": "^2.8.2",


### PR DESCRIPTION
Peer dependencies more annoying than useful. Can't install this without warnings because webpack is now at `^1.10.1`.